### PR TITLE
Create stream and request functions

### DIFF
--- a/lib/weedx/operation.ex
+++ b/lib/weedx/operation.ex
@@ -30,8 +30,8 @@ defmodule Weedx.Operation do
     })
   end
 
-  @spec move_request(String.t(), String.t()) :: AtomicRenameEntryResponse.t()
-  def move_request(old_path, new_path) do
+  @spec move(String.t(), String.t()) :: AtomicRenameEntryResponse.t()
+  def move(old_path, new_path) do
     old_dir = Path.dirname(old_path)
     old_name = Path.basename(old_path)
     new_dir = Path.dirname(new_path)


### PR DESCRIPTION
Reduce the public API of `weedx` to only two functions.

`request` that will take a request param to execute and an optional configuration overrides.

`stream` that returns a stream, only available for certain requests.